### PR TITLE
Add error handlers

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+continuation_indent_size = 8
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.bat]
+end_of_line = crlf
+
+[build.gradle]
+continuation_indent_size = 4
+
+[.idea/codeStyles/*.xml]
+indent_size = 2
+insert_final_newline = false

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>network.bisq.btcd-cli4j</groupId>
 		<artifactId>btcd-cli4j-parent</artifactId>
-		<version>0.5.8.3</version>
+		<version>0.5.8.4</version>
 	</parent>
 	<artifactId>btcd-cli4j-core</artifactId>
 	<packaging>jar</packaging>

--- a/core/src/main/java/com/neemre/btcdcli4j/core/BtcdCli4jVersion.java
+++ b/core/src/main/java/com/neemre/btcdcli4j/core/BtcdCli4jVersion.java
@@ -1,0 +1,22 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.neemre.btcdcli4j.core;
+
+public class BtcdCli4jVersion {
+    public static final String VERSION = "0.5.8.4";
+}

--- a/daemon/pom.xml
+++ b/daemon/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>network.bisq.btcd-cli4j</groupId>
 		<artifactId>btcd-cli4j-parent</artifactId>
-		<version>0.5.8.3</version>
+		<version>0.5.8.4</version>
 	</parent>
 	<artifactId>btcd-cli4j-daemon</artifactId>
 	<packaging>jar</packaging>

--- a/daemon/pom.xml
+++ b/daemon/pom.xml
@@ -25,5 +25,15 @@
 			<artifactId>slf4j-api</artifactId>
 			<version>${slf4j.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+			<version>20.0</version>
+		</dependency>
+		<dependency>
+			<groupId>com.google.code.findbugs</groupId>
+			<artifactId>jsr305</artifactId>
+			<version>3.0.2</version>
+		</dependency>
 	</dependencies>
 </project>

--- a/daemon/src/main/java/com/neemre/btcdcli4j/daemon/NotificationHandlerException.java
+++ b/daemon/src/main/java/com/neemre/btcdcli4j/daemon/NotificationHandlerException.java
@@ -30,7 +30,7 @@ public class NotificationHandlerException extends Exception {
         code = error.getCode();
     }
 
-    public NotificationHandlerException(Errors error, Exception cause) {
+    public NotificationHandlerException(Errors error, Throwable cause) {
         super(error.getDescription(), cause);
         code = error.getCode();
     }

--- a/daemon/src/main/java/com/neemre/btcdcli4j/daemon/NotificationHandlerException.java
+++ b/daemon/src/main/java/com/neemre/btcdcli4j/daemon/NotificationHandlerException.java
@@ -17,9 +17,8 @@ import lombok.ToString;
 public class NotificationHandlerException extends Exception {
 
     private static final long serialVersionUID = 1L;
-
+    private final Errors error;
     private int code;
-
 
     public NotificationHandlerException(Errors error) {
         this(error, Constants.STRING_EMPTY);
@@ -27,11 +26,13 @@ public class NotificationHandlerException extends Exception {
 
     public NotificationHandlerException(Errors error, String additionalMsg) {
         super(error.getDescription() + additionalMsg);
+        this.error = error;
         code = error.getCode();
     }
 
     public NotificationHandlerException(Errors error, Throwable cause) {
         super(error.getDescription(), cause);
+        this.error = error;
         code = error.getCode();
     }
 }

--- a/daemon/src/main/java/com/neemre/btcdcli4j/daemon/NotificationHandlerException.java
+++ b/daemon/src/main/java/com/neemre/btcdcli4j/daemon/NotificationHandlerException.java
@@ -14,7 +14,7 @@ import lombok.ToString;
 @Data
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = false)
-public class NotificationHandlerException extends RuntimeException {
+public class NotificationHandlerException extends Exception {
 
     private static final long serialVersionUID = 1L;
 

--- a/daemon/src/main/java/com/neemre/btcdcli4j/daemon/notification/NotificationMonitor.java
+++ b/daemon/src/main/java/com/neemre/btcdcli4j/daemon/notification/NotificationMonitor.java
@@ -97,7 +97,7 @@ public class NotificationMonitor extends Observable implements Observer, Callabl
                 throw new NotificationHandlerException(Errors.IO_SOCKET_UNINITIALIZED, e);
             } catch (Throwable e) {
                 Thread.currentThread().interrupt();
-                throw new NotificationHandlerException(Errors.IO_SOCKET_UNINITIALIZED);
+                throw new NotificationHandlerException(Errors.IO_SOCKET_UNINITIALIZED, e);
             } finally {
                 if (Thread.interrupted()) {
                     deactivate();

--- a/daemon/src/main/java/com/neemre/btcdcli4j/daemon/notification/NotificationMonitor.java
+++ b/daemon/src/main/java/com/neemre/btcdcli4j/daemon/notification/NotificationMonitor.java
@@ -1,5 +1,6 @@
 package com.neemre.btcdcli4j.daemon.notification;
 
+import com.google.common.util.concurrent.*;
 import com.neemre.btcdcli4j.core.client.BtcdClient;
 import com.neemre.btcdcli4j.core.common.Constants;
 import com.neemre.btcdcli4j.core.common.Errors;
@@ -11,17 +12,20 @@ import com.neemre.btcdcli4j.daemon.notification.worker.NotificationWorkerFactory
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketTimeoutException;
 import java.util.Observable;
 import java.util.Observer;
+import java.util.concurrent.Callable;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 
-public class NotificationMonitor extends Observable implements Observer, Runnable {
+public class NotificationMonitor extends Observable implements Observer, Callable<Void> {
 
     private static final Logger LOG = LoggerFactory.getLogger(NotificationMonitor.class);
     private static final int WORKER_MIN_COUNT = 1;
@@ -34,22 +38,33 @@ public class NotificationMonitor extends Observable implements Observer, Runnabl
     private int serverPort;
     private ServerSocket serverSocket;
     private volatile boolean isActive;
-    private ThreadPoolExecutor workerPool;
 
+    @Nullable
     private BtcdClient client;
+    @Nullable
+    private Consumer<Throwable> errorHandler;
 
+    private ThreadPoolExecutor executor;
+    private ListeningExecutorService workerPool;
 
-    public NotificationMonitor(Notifications type, int serverPort, BtcdClient client) {
+    public NotificationMonitor(Notifications type, int serverPort, @Nullable BtcdClient client) {
+        this(type, serverPort, client, null);
+    }
+
+    public NotificationMonitor(Notifications type, int serverPort, @Nullable BtcdClient client,
+                               @Nullable Consumer<Throwable> errorHandler) {
         LOG.info("** NotificationMonitor(): launching new '{}' notification monitor (port: '{}', "
                 + "RPC-capable: '{}')", type.name(), serverPort, ((client == null) ? "no" : "yes"));
+        this.errorHandler = errorHandler;
         this.type = type;
         this.serverPort = serverPort;
         this.client = client;
     }
 
     @Override
-    public void run() {
+    public Void call() throws NotificationHandlerException {
         activate();
+
         LOG.info("-- run(..): started listening for '{}' notifications on port '{}'", type.name(),
                 serverSocket.getLocalPort());
         while (isActive) {
@@ -57,22 +72,39 @@ public class NotificationMonitor extends Observable implements Observer, Runnabl
                 Socket socket = serverSocket.accept();
                 NotificationWorker worker = NotificationWorkerFactory.createWorker(type, socket, client);
                 worker.addObserver(this);
-                workerPool.submit(worker);
+
+                ListenableFuture<Void> future = workerPool.submit(worker);
+
+                Futures.addCallback(future, new FutureCallback<Void>() {
+                    public void onSuccess(Void ignore) {
+                    }
+
+                    public void onFailure(Throwable throwable) {
+                        if (errorHandler != null)
+                            errorHandler.accept(throwable);
+                    }
+                });
+
                 LOG.trace("-- run(..): total no. of '{}' notifications received: '{}', task queue "
-                                + "occupancy: '{}/{}'", type.name(), workerPool.getTaskCount(),
-                        workerPool.getQueue().size(), TASK_QUEUE_LENGTH);
+                                + "occupancy: '{}/{}'", type.name(), executor.getTaskCount(),
+                        executor.getQueue().size(), TASK_QUEUE_LENGTH);
+
             } catch (SocketTimeoutException e) {
                 LOG.trace("-- run(..): polling '{}' notification monitor for interrupts (socket idle "
                         + "for {}ms)", type.name(), IDLE_SOCKET_TIMEOUT);
             } catch (IOException e) {
                 Thread.currentThread().interrupt();
                 throw new NotificationHandlerException(Errors.IO_SOCKET_UNINITIALIZED, e);
+            } catch (Throwable e) {
+                Thread.currentThread().interrupt();
+                throw new NotificationHandlerException(Errors.IO_SOCKET_UNINITIALIZED);
             } finally {
                 if (Thread.interrupted()) {
                     deactivate();
                 }
             }
         }
+        return null;
     }
 
     @Override
@@ -88,7 +120,7 @@ public class NotificationMonitor extends Observable implements Observer, Runnabl
         return isActive;
     }
 
-    private void activate() {
+    private void activate() throws NotificationHandlerException {
         Thread.currentThread().setName(getUniqueName());
         isActive = true;
         try {
@@ -105,8 +137,12 @@ public class NotificationMonitor extends Observable implements Observer, Runnabl
                 throw new NotificationHandlerException(Errors.IO_SERVERSOCKET_UNINITIALIZED, e);
             }
         }
-        workerPool = new ThreadPoolExecutor(WORKER_MIN_COUNT, WORKER_MAX_COUNT, IDLE_WORKER_TIMEOUT,
-                TimeUnit.MILLISECONDS, new LinkedBlockingQueue<Runnable>(TASK_QUEUE_LENGTH));
+
+        executor = new ThreadPoolExecutor(WORKER_MIN_COUNT, WORKER_MAX_COUNT, IDLE_WORKER_TIMEOUT,
+                TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>(TASK_QUEUE_LENGTH));
+        executor.allowCoreThreadTimeOut(true);
+        executor.setRejectedExecutionHandler((r, e) -> LOG.error("RejectedExecutionHandler called"));
+        workerPool = MoreExecutors.listeningDecorator(executor);
     }
 
     private void deactivate() {

--- a/daemon/src/main/java/com/neemre/btcdcli4j/daemon/notification/worker/NotificationWorker.java
+++ b/daemon/src/main/java/com/neemre/btcdcli4j/daemon/notification/worker/NotificationWorker.java
@@ -64,7 +64,7 @@ public abstract class NotificationWorker extends Observable implements Callable<
             throw new NotificationHandlerException(Errors.IO_UNKNOWN, e);
         } catch (Throwable e) {
             LOG.error("Throwable at NotificationWorker: e={}, notification={}", e.toString(), notification);
-            throw new NotificationHandlerException(Errors.IO_UNKNOWN);
+            throw new NotificationHandlerException(Errors.IO_UNKNOWN, e);
         } finally {
             if (socket != null) {
                 try {

--- a/daemon/src/main/java/com/neemre/btcdcli4j/daemon/notification/worker/NotificationWorker.java
+++ b/daemon/src/main/java/com/neemre/btcdcli4j/daemon/notification/worker/NotificationWorker.java
@@ -17,8 +17,9 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.Socket;
 import java.util.Observable;
+import java.util.concurrent.Callable;
 
-public abstract class NotificationWorker extends Observable implements Runnable {
+public abstract class NotificationWorker extends Observable implements Callable<Void> {
 
     private static final Logger LOG = LoggerFactory.getLogger(NotificationWorker.class);
 
@@ -35,7 +36,8 @@ public abstract class NotificationWorker extends Observable implements Runnable 
     }
 
     @Override
-    public void run() {
+    public Void call() throws NotificationHandlerException {
+        String notification = "null";
         try {
             Thread.currentThread().setName(getUniqueName());
             BufferedReader reader = new BufferedReader(new InputStreamReader(socket.getInputStream(),
@@ -44,10 +46,10 @@ public abstract class NotificationWorker extends Observable implements Runnable 
             for (String line = reader.readLine(); line != null; line = reader.readLine()) {
                 notificationBuilder.append(line);
             }
-            String notification = notificationBuilder.toString().trim();
+            notification = notificationBuilder.toString().trim();
             LOG.debug("-- run(..): received new '{}' notification as (raw): '{}'", getType().name(),
                     notification);
-            Object relatedEntity = null;
+            Object relatedEntity;
             try {
                 relatedEntity = getRelatedEntity(notification);
                 setChanged();
@@ -58,7 +60,11 @@ public abstract class NotificationWorker extends Observable implements Runnable 
                 throw new NotificationHandlerException(Errors.IO_BITCOIND, e);
             }
         } catch (IOException e) {
+            LOG.error("IOException at NotificationWorker: e={}, notification={}", e.toString(), notification);
             throw new NotificationHandlerException(Errors.IO_UNKNOWN, e);
+        } catch (Throwable e) {
+            LOG.error("Throwable at NotificationWorker: e={}, notification={}", e.toString(), notification);
+            throw new NotificationHandlerException(Errors.IO_UNKNOWN);
         } finally {
             if (socket != null) {
                 try {
@@ -71,6 +77,7 @@ public abstract class NotificationWorker extends Observable implements Runnable 
                 }
             }
         }
+        return null;
     }
 
     protected abstract Object getRelatedEntity(String notification) throws CommunicationException, BitcoindException;

--- a/daemon/src/main/java/com/neemre/btcdcli4j/daemon/notification/worker/NotificationWorkerFactory.java
+++ b/daemon/src/main/java/com/neemre/btcdcli4j/daemon/notification/worker/NotificationWorkerFactory.java
@@ -6,22 +6,26 @@ import com.neemre.btcdcli4j.daemon.Notifications;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
+import javax.annotation.Nullable;
 import java.net.Socket;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class NotificationWorkerFactory {
 
     public static NotificationWorker createWorker(Notifications type, Socket socket,
-                                                  BtcdClient client) {
+                                                  @Nullable BtcdClient client) {
         if (type.equals(Notifications.ALERT)) {
             return new AlertNotificationWorker(socket);
         } else if (type.equals(Notifications.BLOCK)) {
+            checkNotNull(client, "client must not be null in case of Notifications.BLOCK");
             return new BlockNotificationWorker(socket, client);
         } else if (type.equals(Notifications.WALLET)) {
+            checkNotNull(client, "client must not be null in case of Notifications.WALLET");
             return new WalletNotificationWorker(socket, client);
         } else {
-            throw new IllegalArgumentException(Errors.ARGS_BTCD_NOTIFICATION_UNSUPPORTED
-                    .getDescription());
+            throw new IllegalArgumentException(Errors.ARGS_BTCD_NOTIFICATION_UNSUPPORTED.getDescription());
         }
     }
 }

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>network.bisq.btcd-cli4j</groupId>
 		<artifactId>btcd-cli4j-parent</artifactId>
-        <version>0.5.8.3</version>
+        <version>0.5.8.4</version>
 	</parent>
 	<artifactId>btcd-cli4j-examples</artifactId>
 	<packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>network.bisq.btcd-cli4j</groupId>
 	<artifactId>btcd-cli4j-parent</artifactId>
-	<version>0.5.8.3</version>
+	<version>0.5.8.4</version>
 	<packaging>pom</packaging>
 
 	<name>btcd-cli4j Parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-		<jdk.version>1.7</jdk.version>
+		<jdk.version>1.8</jdk.version>
 		<jackson.version>2.5.0</jackson.version>
 		<slf4j.version>1.7.10</slf4j.version>
 		<commons-lang.version>3.3.2</commons-lang.version>


### PR DESCRIPTION
I got locally IO exceptions with Bitcoin core RPC connection and it was not propaged to the Bisq RPCService class. This PR adds support for error handlers to get notified about such exceptions and to react accordingly.

- Use Callable instead of Runnable to support exception handling
- Add error handler to forward exceptions in threads to client
- Add more logs
- Add Nullable annotation
- Use ListeningExecutorService
- Catch generic exceptions
- Make NotificationHandlerException checked exception
- Set version 0.5.8.4