### PR TITLE
Use latest guava 27

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>network.bisq.btcd-cli4j</groupId>
 		<artifactId>btcd-cli4j-parent</artifactId>
-		<version>0.5.8.4</version>
+		<version>0.5.8.5</version>
 	</parent>
 	<artifactId>btcd-cli4j-core</artifactId>
 	<packaging>jar</packaging>

--- a/core/src/main/java/com/neemre/btcdcli4j/core/BtcdCli4jVersion.java
+++ b/core/src/main/java/com/neemre/btcdcli4j/core/BtcdCli4jVersion.java
@@ -18,5 +18,5 @@
 package com.neemre.btcdcli4j.core;
 
 public class BtcdCli4jVersion {
-    public static final String VERSION = "0.5.8.4";
+    public static final String VERSION = "0.5.8.5";
 }

--- a/daemon/pom.xml
+++ b/daemon/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>network.bisq.btcd-cli4j</groupId>
 		<artifactId>btcd-cli4j-parent</artifactId>
-		<version>0.5.8.4</version>
+		<version>0.5.8.5</version>
 	</parent>
 	<artifactId>btcd-cli4j-daemon</artifactId>
 	<packaging>jar</packaging>

--- a/daemon/pom.xml
+++ b/daemon/pom.xml
@@ -28,7 +28,7 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>20.0</version>
+			<version>27.0.1-jre</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.code.findbugs</groupId>

--- a/daemon/src/main/java/com/neemre/btcdcli4j/daemon/BtcdDaemonImpl.java
+++ b/daemon/src/main/java/com/neemre/btcdcli4j/daemon/BtcdDaemonImpl.java
@@ -20,6 +20,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.function.Consumer;
 
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
+
 public class BtcdDaemonImpl implements BtcdDaemon {
 
     private static final Logger LOG = LoggerFactory.getLogger(BtcdDaemonImpl.class);
@@ -218,7 +220,7 @@ public class BtcdDaemonImpl implements BtcdDaemon {
                     if (errorHandler != null)
                         errorHandler.accept(throwable);
                 }
-            });
+            }, directExecutor());
         }
     }
 }

--- a/daemon/src/main/java/com/neemre/btcdcli4j/daemon/notification/NotificationMonitor.java
+++ b/daemon/src/main/java/com/neemre/btcdcli4j/daemon/notification/NotificationMonitor.java
@@ -25,6 +25,8 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
+
 public class NotificationMonitor extends Observable implements Observer, Callable<Void> {
 
     private static final Logger LOG = LoggerFactory.getLogger(NotificationMonitor.class);
@@ -83,7 +85,7 @@ public class NotificationMonitor extends Observable implements Observer, Callabl
                         if (errorHandler != null)
                             errorHandler.accept(throwable);
                     }
-                });
+                }, directExecutor());
 
                 LOG.trace("-- run(..): total no. of '{}' notifications received: '{}', task queue "
                                 + "occupancy: '{}/{}'", type.name(), executor.getTaskCount(),

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>network.bisq.btcd-cli4j</groupId>
 		<artifactId>btcd-cli4j-parent</artifactId>
-        <version>0.5.8.4</version>
+        <version>0.5.8.5</version>
 	</parent>
 	<artifactId>btcd-cli4j-examples</artifactId>
 	<packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>network.bisq.btcd-cli4j</groupId>
 	<artifactId>btcd-cli4j-parent</artifactId>
-	<version>0.5.8.4</version>
+	<version>0.5.8.5</version>
 	<packaging>pom</packaging>
 
 	<name>btcd-cli4j Parent</name>


### PR DESCRIPTION
In order to utilize BitcoinJ 0.15, we need to update to guava 27 as per this comment: https://github.com/bisq-network/bisq/pull/2772#issuecomment-493788916

As a result, needed to update deprecated use of Futures.addCallback.