### PR TITLE
Revert guava version to 20.0

### DIFF
--- a/daemon/pom.xml
+++ b/daemon/pom.xml
@@ -28,7 +28,7 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>27.0.1-jre</version>
+			<version>20.0</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.code.findbugs</groupId>


### PR DESCRIPTION
Better to not upgrade libraries if not urgently needed